### PR TITLE
write ispg = 0 for 2d mrc images

### DIFF
--- a/core/rwMRC.cpp
+++ b/core/rwMRC.cpp
@@ -582,7 +582,7 @@ int ImageBase::writeMRC(size_t select_img, bool isStack, int mode, const String 
         }
     }
     else // To set in the header that the file is a volume not a stack
-        header->ispg = 1;
+        header->ispg = (Zdim>1)? 1:0;
 
     //locking
     FileLock flock;


### PR DESCRIPTION
This was already explored by @cossorzano and should fix the ispg wrong value.