### PR TITLE
Add alignment-related utility functions for xmipp_starpu_reconstruct_fourier

### DIFF
--- a/core/utils/memory_utils.h
+++ b/core/utils/memory_utils.h
@@ -28,6 +28,7 @@
 
 #include <cstddef>
 #include <stdlib.h>
+#include <cstdint>
 
 namespace memoryUtils
 {
@@ -85,6 +86,37 @@ namespace memoryUtils
     inline constexpr T GB(T bytes) {
       return  bytes / ((T)1024 * (T)1024 * (T)1024);
     }
+
+    /** Returns the current alignment of the ptr.
+     * Essentially just counts the amount of LSB zeros.
+     * Returns 2^31 for ptr == 0. */
+	inline uint32_t alignmentOf(uintptr_t ptr) {
+		for (uint32_t alignPower = 0; alignPower < 32; alignPower++) {
+			const uint32_t alignment = 1u << alignPower;
+			if ((ptr & alignment) != 0) {
+				return alignment;
+			}
+		}
+		return 1u << 31u;
+	}
+
+	/** Convenience shortcut for alignmentOf(uintptr_t). */
+	inline uint32_t alignmentOf(void * ptr) {
+		return alignmentOf((size_t) ptr);
+	}
+
+	/** Return number + N, where N is the smallest non-negative number required to make number have given alignment.
+	 * Example: align(13, 8) = 16 */
+	template<typename T>
+	inline T align(T number, uint32_t alignment) {
+		T off = number % alignment;
+		if (off == 0) {
+			return number;
+		} else {
+			return number + alignment - off;
+		}
+	}
+
 } // memoryUtils
 
 #endif /* CORE_UTILS_MEMORY_UTILS_H_ */

--- a/core/xmipp_macros.h
+++ b/core/xmipp_macros.h
@@ -458,6 +458,15 @@
 #define SUM_INIT(var, value) if (first_time) var = (value); else var += (value);
 #define SUM_INIT_COND(var, value, cond) if (cond) var = (value); else var += (value);
 
+/** XMIPP_ASSUME_ALIGNED(ptr, alignment)
+ * Tell compiler to assume, that ptr has given alignment, even if the compiler can't prove it.
+ * This serves as a performance hint, useful to allow auto-vectorization. */
+#ifdef __GNUC__
+#  define XMIPP_ASSUME_ALIGNED(ptr, alignment) (__builtin_assume_aligned(ptr, alignment))
+#else
+#  define XMIPP_ASSUME_ALIGNED(ptr, alignment) (ptr)
+#endif
+
 //@}
 //@}
 #endif


### PR DESCRIPTION
As suggested in I2PC/xmipp#185 .

Replacement for #38 on an in-repo branch.