### PR TITLE
Dmt xmipp error inheritance

### DIFF
--- a/core/xmipp_error.cpp
+++ b/core/xmipp_error.cpp
@@ -40,8 +40,9 @@ void _Xmipp_error(const ErrorType nerr, const String &what,
 
 // Object Constructor
 XmippError::XmippError(const ErrorType nerr, const String &what,
-                       const String &fileArg, const long lineArg)
+                       const String &fileArg, const long lineArg):std::runtime_error(what)
 {
+    std::runtime_error(what.c_str());
     __errno = nerr;
     msg = colorString(what.c_str(), RED);
     file = fileArg;
@@ -53,15 +54,15 @@ XmippError::XmippError(const ErrorType nerr, const String &what,
     //Store information about the stack calls
 //#ifdef LINUX
 //    void *array[10];
-//    size = backtrace(array, 10);
-//    strings = backtrace_symbols(array, size);
+//    size_t size = backtrace(array, 10);
+//    char ** strings = backtrace_symbols(array, size);
 //#endif
 }
 
-//Object Destructor
-XmippError::~XmippError()
+XmippError::XmippError(const std::string &what):std::runtime_error(what)
 {
-    //free(strings);
+   std::runtime_error(what.c_str());
+   XmippError(ERR_UNCLASSIFIED,what,"Unknown file",0);
 }
 
 // Show message
@@ -236,6 +237,11 @@ String XmippError::getDefaultMessage(ErrorType e)
     default:
         return "Unrecognized error code";
     }
+}
+
+const char* XmippError::what() const noexcept
+{
+  return getDefaultMessage().c_str();
 }
 
 void reportWarning(const String& what)

--- a/core/xmipp_error.cpp
+++ b/core/xmipp_error.cpp
@@ -40,9 +40,8 @@ void _Xmipp_error(const ErrorType nerr, const String &what,
 
 // Object Constructor
 XmippError::XmippError(const ErrorType nerr, const String &what,
-                       const String &fileArg, const long lineArg):std::runtime_error(what)
+                       const String &fileArg, const long lineArg):std::runtime_error(what.c_str())
 {
-    std::runtime_error(what.c_str());
     __errno = nerr;
     msg = colorString(what.c_str(), RED);
     file = fileArg;
@@ -59,10 +58,9 @@ XmippError::XmippError(const ErrorType nerr, const String &what,
 //#endif
 }
 
-XmippError::XmippError(const std::string &what):std::runtime_error(what)
+XmippError::XmippError(const std::string &what):XmippError(ERR_UNCLASSIFIED,what,"Unknown file",0)
 {
-   std::runtime_error(what.c_str());
-   XmippError(ERR_UNCLASSIFIED,what,"Unknown file",0);
+
 }
 
 // Show message
@@ -241,7 +239,7 @@ String XmippError::getDefaultMessage(ErrorType e)
 
 const char* XmippError::what() const noexcept
 {
-  return getDefaultMessage().c_str();
+  return getMessage().c_str();
 }
 
 void reportWarning(const String& what)

--- a/core/xmipp_error.h
+++ b/core/xmipp_error.h
@@ -25,7 +25,7 @@
 
 #ifndef CORE_XMIPP_ERROR_H
 #define CORE_XMIPP_ERROR_H
-
+#include <stdexcept>
 #include <iostream>
 #include "xmipp_strings.h"
 
@@ -245,14 +245,8 @@ void _Xmipp_error(const ErrorType nerr, const String& what,
  * exception handling mode is active (see Xmipp Configuration for details about
  * enabling the exception handling).
  */
-class XmippError
+class XmippError : public std::runtime_error
 {
-
-private:
-    //Variables to hold stack info
-    char ** strings;
-    size_t size;
-
 public:
     /** Error code */
     ErrorType __errno;
@@ -269,8 +263,9 @@ public:
     /** Constructor */
     XmippError(const ErrorType nerr, const String& what,
                const String &fileArg, const long lineArg);
-    /** Destructor */
-    ~XmippError();
+
+    /** Constructor */
+    XmippError(const std::string& what);
 
     /** Show an error */
     friend std::ostream& operator<<(std::ostream& o, XmippError& XE);
@@ -284,6 +279,8 @@ public:
     /** Get default message */
     static String getDefaultMessage(ErrorType e);
 
+    /** Get error message */
+    virtual char const * what() const noexcept;
 
 };
 

--- a/core/xmipp_error.h
+++ b/core/xmipp_error.h
@@ -280,7 +280,7 @@ public:
     static String getDefaultMessage(ErrorType e);
 
     /** Get error message */
-    virtual char const * what() const noexcept;
+    virtual char const * what() const noexcept override;
 
 };
 


### PR DESCRIPTION
XmippError inherit from std::runtime_error
-Add a new (simpler) constructor
-Add what() method