### PR TITLE
maintenance: removing `seed` from `xmipp_program`

### DIFF
--- a/core/xmipp_program.h
+++ b/core/xmipp_program.h
@@ -157,8 +157,8 @@ public:
 
     /// Verbosity level
     int verbose;
-    /** debug flag and seed for randomization */
-    int debug, seed;
+    /** debug flag*/
+    int debug;
 
     /** @name Public common functions
      * The functions in this section are available for all programs


### PR DESCRIPTION
Closes #150 