### PR TITLE
maintenance: adding methods for loading float param

### DIFF
--- a/core/xmipp_program.cpp
+++ b/core/xmipp_program.cpp
@@ -368,6 +368,16 @@ double XmippProgram::getDoubleParam(const char * param, const char * subparam, i
     return textToFloat(progDef->getParam(param, subparam, arg));
 }
 
+float XmippProgram::getFloatParam(const char * param, int arg)
+{
+    return textToFloat(progDef->getParam(param, arg));
+}
+
+float XmippProgram::getFloatParam(const char * param, const char * subparam, int arg)
+{
+    return textToFloat(progDef->getParam(param, subparam, arg));
+}
+
 void XmippProgram::getListParam(const char * param, StringVector &list)
 {
     ParamDef * paramDef = progDef->findParam(param);

--- a/core/xmipp_program.h
+++ b/core/xmipp_program.h
@@ -139,6 +139,8 @@ public:
     int getIntParam(const char * param, const char * subparam, int arg = 0);
     double getDoubleParam(const char * param, int arg = 0);
     double getDoubleParam(const char * param, const char * subparam, int arg = 0);
+    float getFloatParam(const char * param, int arg = 0);
+    float getFloatParam(const char * param, const char * subparam, int arg = 0);
     /** Get arguments supplied to param as a list */
     void getListParam(const char * param, StringVector &list);
     /** Get the number of arguments supplied to the param */


### PR DESCRIPTION
this might help with sonarcloud issues when you try to store `getDoubleParam` to float variable