### PR TITLE
Maintenance: fixing dangling pointer in xmipp_error

### DIFF
--- a/core/geometry.cpp
+++ b/core/geometry.cpp
@@ -960,15 +960,7 @@ void Euler_Angles_after_compresion(const double rot, double tilt, double psi,
     Matrix2D<double> D_1(3, 3);
 
     //if D has not inverse we are not in business
-    try
-    {
-        D_1 = D.inv();
-    }
-    catch (XmippError &XE)
-    {
-        std::cout << XE;
-        exit(1);
-    }
+    D_1 = D.inv();
 
     Euler_direction(rot, tilt, psi, w);
     if (fabs(w(2)) > 0.999847695)/*cos one degree */

--- a/core/xmipp_error.cpp
+++ b/core/xmipp_error.cpp
@@ -27,64 +27,19 @@
 #include "xmipp_error.h"
 #include "xmipp_color.h"
 
-/* Exception handling ------------------------------------------------------ */
-void _Xmipp_error(const ErrorType nerr, const String &what,
-                  const String &file, const long line)
-{
-    XmippError xe(nerr, what, file, line);
-    std::cerr << xe << std::endl;
-    //std::cout << nerr << ": " << what << std::endl
-    //<< "File: " << file << " line: " << line << std::endl;
-    exit(nerr);
-}
 
 // Object Constructor
 XmippError::XmippError(const ErrorType nerr, const String &what,
-                       const String &fileArg, const long lineArg):std::runtime_error(what.c_str())
-{
-    __errno = nerr;
-    msg = colorString(what.c_str(), RED);
-    file = fileArg;
-    line = lineArg;
-    char* path = getenv("XMIPP_DEBUG");
-    if (path != NULL)
-        std::cout << "XMIPP_DEBUG: " << getMessage() << std::endl;
+                       const String &fileArg, const long lineArg)
+                       :std::runtime_error(XmippError::getMessage(nerr, what, fileArg, lineArg)), __errno(nerr)
+{}
 
-    //Store information about the stack calls
-//#ifdef LINUX
-//    void *array[10];
-//    size_t size = backtrace(array, 10);
-//    char ** strings = backtrace_symbols(array, size);
-//#endif
-}
-
-XmippError::XmippError(const std::string &what):XmippError(ERR_UNCLASSIFIED,what,"Unknown file",0)
-{
-
-}
-
-// Show message
-std::ostream& operator << (std::ostream& o, XmippError& xe)
-{
-    String error = formatString("XMIPP_ERROR %d: %s", xe.__errno, xe.getDefaultMessage().c_str());
-    o << colorString(error.c_str(), RED) << std::endl;
-    o << colorString(xe.msg.c_str(), RED) << std::endl;
-    error = formatString("File: %s line: %ld", xe.file.c_str(), xe.line);
-    o << colorString(error.c_str(), RED) << std::endl;
-    return o;
-}
-
-String XmippError::getMessage() const
-{
-      String error = formatString("XMIPP_ERROR %d: %s\n   ", __errno, getDefaultMessage().c_str());
-      error += msg;
-      error += formatString("\n   File: %s line: %ld\n", file.c_str(), line);
+String XmippError::getMessage(const ErrorType nerr, const String& what,
+               const String &fileArg, const long lineArg) {
+      String error = formatString("XMIPP_ERROR %d: %s\n   ", nerr, getDefaultMessage(nerr).c_str());
+      error += what;
+      error += formatString("\n   File: %s line: %ld\n", fileArg.c_str(), lineArg);
       return error;
-}
-
-String XmippError::getDefaultMessage() const
-{
-    return getDefaultMessage(__errno);
 }
 
 String XmippError::getDefaultMessage(ErrorType e)
@@ -235,11 +190,6 @@ String XmippError::getDefaultMessage(ErrorType e)
     default:
         return "Unrecognized error code";
     }
-}
-
-const char* XmippError::what() const noexcept
-{
-  return getMessage().c_str();
 }
 
 void reportWarning(const String& what)

--- a/core/xmipp_error.h
+++ b/core/xmipp_error.h
@@ -23,15 +23,11 @@
 *  e-mail address 'xmipp@cnb.csic.es'
 ***************************************************************************/
 
-#ifndef CORE_XMIPP_ERROR_H
-#define CORE_XMIPP_ERROR_H
-#include <stdexcept>
-#include <iostream>
-#include "xmipp_strings.h"
+#pragma once
 
-#ifdef LINUX
-#include <execinfo.h>
-#endif
+#include <stdexcept>
+#include "xmipp_strings.h"
+#include <iostream>
 
 /** @defgroup ErrorHandling Error handling
  * @ingroup DataLibrary
@@ -204,28 +200,6 @@ enum ErrorType
 };
 
 
-/** MACROs that process XMIPP exceptions
- */
-#define XMIPP_TRY try{
-
-#define XMIPP_CATCH \
-	}\
-    catch (XmippError &xe)\
-    {\
-        std::cerr << xe;\
-        exit(-1);\
-    }
-
-/** Show message and exit
- *
- * This is an internal function (not to be used by programmers)
- * that shows the given message and exits with the error code.
- * This function is called when no exceptions are allowed.
- *
- */
-void _Xmipp_error(const ErrorType nerr, const String& what,
-                  const String &file, const long line);
-
 /** Show message and throw exception
  *
  * This macro shows the given message and exits with the error code.
@@ -248,40 +222,18 @@ void _Xmipp_error(const ErrorType nerr, const String& what,
 class XmippError : public std::runtime_error
 {
 public:
-    /** Error code */
-    ErrorType __errno;
-
-    /** Message shown */
-    String msg;
-
-    /** File producing the error */
-    String file;
-
-    /** Line number */
-    long line;
-
-    /** Constructor */
     XmippError(const ErrorType nerr, const String& what,
                const String &fileArg, const long lineArg);
 
-    /** Constructor */
-    XmippError(const std::string& what);
+    XmippError(const std::string &what):XmippError(ERR_UNCLASSIFIED,what,"Unknown file",0) {};
 
-    /** Show an error */
-    friend std::ostream& operator<<(std::ostream& o, XmippError& XE);
-
-    /** Get message */
-    String getMessage() const;
-
-    /** Get Default message */
-    String getDefaultMessage() const;
+    ErrorType __errno;
+private:
+    static String getMessage(const ErrorType nerr, const String& what,
+               const String &fileArg, const long lineArg);
 
     /** Get default message */
     static String getDefaultMessage(ErrorType e);
-
-    /** Get error message */
-    virtual char const * what() const noexcept override;
-
 };
 
 /** Print a report warning and continue the execution.
@@ -289,4 +241,3 @@ public:
 void reportWarning(const String& what);
 
 /* @} */
-#endif

--- a/core/xmipp_metadata_program.cpp
+++ b/core/xmipp_metadata_program.cpp
@@ -65,15 +65,7 @@ XmippMetadataProgram::~XmippMetadataProgram()
 
 int XmippMetadataProgram::tryRead(int argc, const char ** argv, bool reportErrors)
 {
-    try
-    {
-        this->read( argc, argv,  reportErrors );
-    }
-    catch (XmippError &xe)
-    {
-        std::cerr << xe;
-        errorCode = xe.__errno;
-    }
+    this->read( argc, argv,  reportErrors );
     return errorCode;
 }
 

--- a/core/xmipp_program.cpp
+++ b/core/xmipp_program.cpp
@@ -209,28 +209,16 @@ void XmippProgram::read(int argc, const char ** argv, bool reportErrors)
     }
     else
     {
-        try
+       
+        this->argc = argc;
+        this->argv = argv;
+        progDef->read(argc, argv, reportErrors);
+        if (!checkBuiltIns())
         {
-            this->argc = argc;
-            this->argv = argv;
-            progDef->read(argc, argv, reportErrors);
-            if (!checkBuiltIns())
-            {
-                if (verbose) //if 0, ignore the parameter, useful for mpi programs
-                    verbose = getIntParam("--verbose");
-                this->readParams();
-                doRun = !checkParam("--xmipp_validate_params"); //just validation, not run
-            }
-        }
-        catch (XmippError &xe)
-        {
-            ///If an input error, shows error message
-            if (verbose)
-            {
-                std::cerr << xe;
-                std::cerr << "For more info use --help" << std::endl;
-            }
-            errorCode = xe.__errno;
+            if (verbose) //if 0, ignore the parameter, useful for mpi programs
+                verbose = getIntParam("--verbose");
+            this->readParams();
+            doRun = !checkParam("--xmipp_validate_params"); //just validation, not run
         }
     }
 }
@@ -255,16 +243,8 @@ void XmippProgram::read(const String &argumentsLine)
 
 int XmippProgram::tryRun()
 {
-    try
-    {
-        if (doRun)
-            this->run();
-    }
-    catch (XmippError &xe)
-    {
-        std::cerr << xe;
-        errorCode = xe.__errno;
-    }
+    if (doRun)
+        this->run();
     return errorCode;
 }
 /** Init progress */

--- a/core/xmipp_threads.cpp
+++ b/core/xmipp_threads.cpp
@@ -189,10 +189,10 @@ void * _threadMain(void * data)
             }
             catch (XmippError &xe)
             {
-                std::cerr << xe << std::endl
+                std::cerr << xe.what() << std::endl
                 << "In thread " << thArg->thread_id << std::endl;
 //                pthread_exit(NULL);
-                exit(-1);
+                exit(xe.__errno);
             }
         }
         else //exit thread


### PR DESCRIPTION
This error was causing crashes without an error message
See also https://github.com/I2PC/xmipp/pull/694