### PR TITLE
Improved MultidimArray performance

### DIFF
--- a/core/multidim_array.cpp
+++ b/core/multidim_array.cpp
@@ -1055,25 +1055,20 @@ void MultidimArray<T>::resize(size_t Ndim, size_t Zdim, size_t Ydim, size_t Xdim
     // Copy needed elements, fill with 0 if necessary
     if (copy)
     {
-        T zero=0; // Very useful for complex matrices
-        T *val=NULL;
-        for (size_t l = 0; l < Ndim; l++)
-            for (size_t k = 0; k < Zdim; k++)
-                for (size_t i = 0; i < Ydim; i++)
-                    for (size_t j = 0; j < Xdim; j++)
-                    {
-                        if (l >= NSIZE(*this))
-                            val = &zero;
-                        else if (k >= ZSIZE(*this))
-                            val = &zero;
-                        else if (i >= YSIZE(*this))
-                            val = &zero;
-                        else if (j >= XSIZE(*this))
-                            val = &zero;
-                        else
-                            val = &DIRECT_NZYX_ELEM(*this, l, k, i, j);
-                        new_data[l*ZYXdim + k*YXdim+i*Xdim+j] = *val;
-                    }
+        const auto nCopy = std::min(Ndim, NSIZE(*this));
+        const auto zCopy = std::min(Zdim, ZSIZE(*this));
+        const auto yCopy = std::min(Ydim, YSIZE(*this));
+        const auto xCopy = std::min(Xdim, XSIZE(*this));
+        const auto xCopyBytes = xCopy*sizeof(T);
+
+        for (size_t l = 0; l < nCopy; ++l) 
+            for (size_t k = 0; k < zCopy; ++k) 
+                for (size_t i = 0; i < yCopy; ++i) 
+                    memcpy(
+                        new_data + l*ZYXdim + k*YXdim + i*Xdim,
+                        data + l*zyxdim + k*yxdim + i*xdim,
+                        xCopyBytes
+                    );
     }
 
     // deallocate old array

--- a/core/multidim_array.h
+++ b/core/multidim_array.h
@@ -163,6 +163,21 @@ public:
         *this = V;
     }
 
+    /** Move constructor
+     *
+     * The created volume is a perfect copy of the input array but with a
+     * different memory assignment.
+     *
+     * @code
+     * MultidimArray< double > V2(V1);
+     * @endcode
+     */
+    MultidimArray(MultidimArray<T>&& V) noexcept
+    {
+        coreInit();
+        swap(V);
+    }
+
     /** Copy constructor from a Matrix1D.
      * The Size constructor creates an array with memory associated,
      * and fills it with zeros.
@@ -211,7 +226,7 @@ public:
     /** Core init.
      * Initialize everything to 0
      */
-    void coreInit()
+    void coreInit() noexcept
     {
         xdim = yxdim = zyxdim = nzyxdim = 0;
         ydim = zdim = ndim = 0;
@@ -221,6 +236,25 @@ public:
         destroyData = true;
         mmapOn = false;
         mFd = NULL;
+    }
+
+    void swap(MultidimArray<T>& other) noexcept
+    {
+        std::swap(xdim, other.xdim);
+        std::swap(ydim, other.ydim);
+        std::swap(zdim, other.zdim);
+        std::swap(ndim, other.ndim);
+        std::swap(yxdim, other.yxdim);
+        std::swap(zyxdim, other.zyxdim);
+        std::swap(nzyxdim, other.nzyxdim);
+        std::swap(xinit, other.xinit);
+        std::swap(yinit, other.yinit);
+        std::swap(zinit, other.zinit);
+        std::swap(data, other.data);
+        std::swap(nzyxdimAlloc, other.nzyxdimAlloc);
+        std::swap(destroyData, other.destroyData);
+        std::swap(mmapOn, other.mmapOn);
+        std::swap(mFd, other.mFd);
     }
 
     /** Core allocate with dimensions.
@@ -312,7 +346,7 @@ public:
     /** Core deallocate.
      * Free all data.
      */
-    void coreDeallocate()
+    void coreDeallocate() noexcept
     {
         if (data != NULL && destroyData)
         {
@@ -3598,6 +3632,27 @@ public:
             if (data == NULL || !sameShape(op1))
                 resizeNoCopy(op1);
             memcpy(data,op1.data,MULTIDIM_SIZE(op1)*sizeof(T));
+        }
+        return *this;
+    }
+
+    /** Move assignment.
+     *
+     * You can build as complex assignment expressions as you like. Multiple
+     * assignment is allowed.
+     *
+     * @code
+     * v1 = v2 + v3;
+     * v1 = v2 = v3;
+     * @endcode
+     */
+    MultidimArray<T>& operator=(MultidimArray<T>&& other) noexcept
+    {
+        if (&other != this)
+        {
+            coreDeallocate();
+            coreInit();
+            swap(other);
         }
         return *this;
     }


### PR DESCRIPTION
Tried to fix 2 issues regarding MultidimArray performance.

- Added move constructor and move assignment. This improves performance when a R-value is asssigned. 
- Modified copies when resizing to make use of `memcpy` instead of manual copies.