### PR TITLE
Transposing matrices for modified volume headers

### DIFF
--- a/core/rwMRC.cpp
+++ b/core/rwMRC.cpp
@@ -92,16 +92,16 @@ struct MRCheadold
 */
 struct MRChead
 {             // file header for MRC data
-    int nx;              //  0   0       image size
-    int ny;              //  1   4
-    int nz;              //  2   8
-    int mode;            //  3           0=char,1=short,2=float,6=uint16
-    int nxStart;         //  4           unit cell offset
-    int nyStart;         //  5
-    int nzStart;         //  6
-    int mx;              //  7           unit cell size in voxels
-    int my;              //  8
-    int mz;              //  9    1=Image or images stack, if volume mz=nz.
+    int32_t nx;              //  0   0       image size
+    int32_t ny;              //  1   4
+    int32_t nz;              //  2   8
+    int32_t mode;            //  3           0=char,1=short,2=float,6=uint16
+    int32_t nxStart;         //  4           unit cell offset
+    int32_t nyStart;         //  5
+    int32_t nzStart;         //  6
+    int32_t mx;              //  7           unit cell size in voxels
+    int32_t my;              //  8
+    int32_t mz;              //  9    1=Image or images stack, if volume mz=nz.
                          //              If ispg=401 then nz=number of volumes in stack * volume z dimension
                          //              mz=volume zdim
     float a;             // 10   40      cell dimensions in A
@@ -110,14 +110,14 @@ struct MRChead
     float alpha;         // 13           cell angles in degrees
     float beta;          // 14
     float gamma;         // 15
-    int mapc;            // 16           column axis
-    int mapr;            // 17           row axis
-    int maps;            // 18           section axis
+    int32_t mapc;            // 16           column axis
+    int32_t mapr;            // 17           row axis
+    int32_t maps;            // 18           section axis
     float amin;          // 19           minimum density value
     float amax;          // 20   80      maximum density value
     float amean;         // 21           average density value
-    int ispg;            // 22           space group number   0=Image/stack,1=Volume,401=volumes stack
-    int nsymbt;          // 23           bytes used for sym. ops. table
+    int32_t ispg;            // 22           space group number   0=Image/stack,1=Volume,401=volumes stack
+    int32_t nsymbt;          // 23           bytes used for sym. ops. table
     float extra[25];     // 24           user-defined info
     float xOrigin;       // 49           phase origin in pixels FIXME: is in pixels or [L] units?
     float yOrigin;       // 50
@@ -125,7 +125,7 @@ struct MRChead
     char map[4];         // 52       identifier for map file ("MAP ")
     char machst[4];      // 53           machine stamp
     float arms;          // 54       RMS deviation
-    int nlabl;           // 55           number of labels used
+    int32_t nlabl;           // 55           number of labels used
     char labels[800];    // 56-255       10 80-character labels
 } ;
 
@@ -165,6 +165,12 @@ int ImageBase::readMRC(size_t start_img, size_t batch_size, bool isStack /* = fa
     _xDim = header->nx;
     _yDim = header->ny;
     _zDim = header->nz;
+
+    // Reading and storing axis order
+    axisOrder[0] = 0;
+    axisOrder[1] = header->mapc;
+    axisOrder[2] = header->mapr;
+    axisOrder[3] = header->maps;
 
     bool isVolStk = (header->ispg > 400);
 

--- a/core/xmipp_image_base.cpp
+++ b/core/xmipp_image_base.cpp
@@ -837,6 +837,9 @@ int ImageBase::_read(const FileName &name, ImageFHandler* hFile, DataMode datamo
 #endif
 #undef DEBUG
 
+    // Defining default axis order (will be overwritten by data types that need it)
+    axisOrder = defaultAxisOrder;
+
     //Just clear the header before reading
     MDMainHeader.clear();
     //Set the file pointer at beginning

--- a/core/xmipp_image_base.h
+++ b/core/xmipp_image_base.h
@@ -27,6 +27,7 @@
 #define CORE_IMAGE_BASE_H_
 
 #include <memory>
+#include <array>
 
 #include "xmipp_image_macros.h"
 #include "xmipp_datatype.h"
@@ -256,6 +257,7 @@ protected:
     size_t              offset;      // Data offset
     int                 swap;        // Perform byte swapping upon reading
     int                 swapWrite;   // Perform byte swapping upon writing
+    std::array<int,4>   axisOrder;   // Order of the axis (tipically 0,1,2,3)
     TransformType       transform;   // Transform type
     size_t              replaceNsize;// Stack size in the replace case
     bool                _exists;     // does target file exists?  // equal 0 if not exists or not a stack
@@ -265,6 +267,8 @@ protected:
     size_t              mappedSize;  // Size of the mapped file
     size_t              mappedOffset;// Offset for the mapped file
     size_t          virtualOffset;// MDA Offset when movePointerTo is used
+
+    static constexpr std::array<int,4> defaultAxisOrder = {0,1,2,3}; // Default axis order 
 
 public:
 


### PR DESCRIPTION
Xmipp, until now, did not read [volume headers](https://www.ccp4.ac.uk/html/maplib.html#description), and assumed a certain order was followed (fields mapc-mapr-maps always were 1,2,3).

This caused some volumes with modified order to not be processed properly within xmipp, being unintentionally transposed.

With this PR, Xmipp will now be able to read any volume with any values of those fields correctly.