### PR TITLE
Added compatibility for undefined axis sequences in MRC files

### DIFF
--- a/core/xmipp_image.h
+++ b/core/xmipp_image.h
@@ -32,6 +32,7 @@
 #define CORE_IMAGE_H
 
 #include <typeinfo>
+#include <set>
 #include "multidim_array.h"
 #include "xmipp_image_base.h"
 #include "xmipp_memory.h"
@@ -1091,6 +1092,12 @@ private:
         ImageBase::setDimensions(aDim);
     }
 
+    static bool isValidAxisOrder(const std::array<int, 4>& order)
+    {
+        std::set<int> uniqueValues(order.cbegin(), order.cend());
+        return uniqueValues.size() == order.size();
+    }
+
     /** Read the raw data
      */
     void
@@ -1122,6 +1129,12 @@ private:
         size_t haveread_n = 0;
 
         selectImgOffset = offset + IMG_INDEX(select_img) * (pagesize + pad);
+
+        if(!isValidAxisOrder(axisOrder))
+        {
+            reportWarning("Image::readData: Invalid axis ordering. Defaulting to 0,1,2,3 ");
+            axisOrder = {0, 1, 2, 3};
+        }
 
         // Flag to know that data is not going to be mapped although mmapOn is true
         if (mmapOnRead && (!checkMmapT(datatype) || swap > 0 || axisOrder != defaultAxisOrder))

--- a/core/xmipp_image.h
+++ b/core/xmipp_image.h
@@ -1094,8 +1094,15 @@ private:
 
     static bool isValidAxisOrder(const std::array<int, 4>& order)
     {
-        std::set<int> uniqueValues(order.cbegin(), order.cend());
-        return uniqueValues.size() == order.size();
+        std::set<int> uniqueValues;
+        
+        for (int value : order) {
+            // Check if the value is not in the range [0, 3] or is not unique.
+            if (value < 0 || value > 3 || !uniqueValues.insert(value).second)
+                return false;
+        }
+
+        return true;
     }
 
     /** Read the raw data


### PR DESCRIPTION
MRC file reads assumed a valid axis ordering in MRC files. This means that `mapc`, `mapr` and `maps` needed to be a permutation of `(1, 2, 3)`. We have found that some files leave these fields are left to zero. This change allows to interpret a default `1,2,3` sequence in those cases.