### PR TITLE
Fix for rare axis orderings in MRC/MAP files

### DIFF
--- a/core/rwMRC.cpp
+++ b/core/rwMRC.cpp
@@ -286,6 +286,7 @@ int ImageBase::readMRC(size_t start_img, size_t batch_size, bool isStack /* = fa
 
     if (dataMode==HEADER || (dataMode == _HEADER_ALL && _nDim > 1)) // Stop reading if not necessary
     {
+        readData(NULL, 0, DT_Unknown, 0); // To consider axis ordering. Will not read actual data
         return errCode;
     }
 
@@ -323,6 +324,12 @@ int ImageBase::readMRC(size_t start_img, size_t batch_size, bool isStack /* = fa
             else if(header->nzStart !=0 && MDMainHeader.getValue(MDL_SAMPLINGRATE_Z,aux))
                 MD[i]->setValue(MDL_ORIGIN_Z, -header->nzStart/aux);
         }
+    }
+
+    if ( dataMode < DATA )   // Don't read the individual header and the data if not necessary
+    {
+        readData(NULL, 0, DT_Unknown, 0); // To consider axis ordering. Will not read actual data
+        return errCode;
     }
 
     // Lets read the data

--- a/core/rwMRC.cpp
+++ b/core/rwMRC.cpp
@@ -325,10 +325,6 @@ int ImageBase::readMRC(size_t start_img, size_t batch_size, bool isStack /* = fa
         }
     }
 
-    if ( dataMode < DATA )   // Don't read the individual header and the data if not necessary
-        return errCode;
-
-
     // Lets read the data
 
     // 4-bits mode: Here is the magic to expand the compressed images

--- a/core/rwMRC.cpp
+++ b/core/rwMRC.cpp
@@ -168,9 +168,9 @@ int ImageBase::readMRC(size_t start_img, size_t batch_size, bool isStack /* = fa
 
     // Reading and storing axis order
     axisOrder[0] = 0;
-    axisOrder[1] = header->mapc;
-    axisOrder[2] = header->mapr;
-    axisOrder[3] = header->maps;
+    axisOrder[1] = 4 - header->maps;
+    axisOrder[2] = 4 - header->mapr;
+    axisOrder[3] = 4 - header->mapc;
 
     bool isVolStk = (header->ispg > 400);
 

--- a/core/xmipp_image.h
+++ b/core/xmipp_image.h
@@ -176,12 +176,53 @@ public:
                 || typeid(T) == typeid(std::complex<float>));
     }
 
+
+    /**
+     * Obtain the inverse axis mapping
+    */
+    void
+    getInverseAxisOrder(const std::array<int,4> &order, 
+                        std::array<int,4> &result )
+    {
+        for (size_t i = 0; i < result.size(); ++i)
+        {
+            size_t j = 0;
+            while(j < order.size() && order[j] != i) ++j; // Find inverse mapping
+            if (j >= order.size())
+                REPORT_ERROR(ERR_LOGIC_ERROR, "Invalid axis mapping");
+            
+            result[i] = j;
+        }
+    }
+
+    /**
+     * Trasposes the given size array according to inverseOrder
+    */
+    void
+    transposeAxisSizes(const std::array<size_t,4> &sizes, 
+                       const std::array<int,4> &order,
+                       std::array<size_t,4> &result )
+    {
+        std::array<int, 4> inverseOrder;
+        getInverseAxisOrder(order, inverseOrder);
+
+        result = {
+            sizes[inverseOrder[0]],
+            sizes[inverseOrder[1]],
+            sizes[inverseOrder[2]],
+            sizes[inverseOrder[3]]
+        };
+    }
+
     /**
      * Trasposes the given MultidimArray with the given order
     */
    void
    transposeInPlace(MultidimArray<T> &multidimArray, const std::array<int,4> &order)
    {
+        std::array<int, 4> inverseOrder;
+        getInverseAxisOrder(order, inverseOrder);
+
         // Creating new multidim array of the same size than the original
         const std::array<size_t,4> sizes = {
             NSIZE(multidimArray),
@@ -190,23 +231,11 @@ public:
             XSIZE(multidimArray)
         };
 
-        // Find the inverse order
-        std::array<size_t,4> inverse_order;
-        for (size_t i = 0; i < inverse_order.size(); ++i)
-        {
-            size_t j = 0;
-            while(j < order.size() && order[j] != i) ++j; // Find inverse mapping
-            if (j >= order.size())
-                REPORT_ERROR(ERR_LOGIC_ERROR, "Invalid axis mapping");
-            
-            inverse_order[i] = j;
-        }
-
         MultidimArray<T> result(
-            sizes[inverse_order[0]],
-            sizes[inverse_order[1]],
-            sizes[inverse_order[2]],
-            sizes[inverse_order[3]]
+            sizes[inverseOrder[0]],
+            sizes[inverseOrder[1]],
+            sizes[inverseOrder[2]],
+            sizes[inverseOrder[3]]
         );
 
         // Performing transposition in a loop for every dimension
@@ -216,10 +245,10 @@ public:
                     for (size_t x = 0; x < XSIZE(multidimArray); x++) {
                         // Defining array to access with the axis orders
                         const std::array<size_t,4> indices = {n, z, y, x};
-                        const auto l = indices[inverse_order[0]];
-                        const auto k = indices[inverse_order[1]];
-                        const auto i = indices[inverse_order[2]];
-                        const auto j = indices[inverse_order[3]];
+                        const auto l = indices[inverseOrder[0]];
+                        const auto k = indices[inverseOrder[1]];
+                        const auto i = indices[inverseOrder[2]];
+                        const auto j = indices[inverseOrder[3]];
 
                         // Transposing element
                         DIRECT_NZYX_ELEM(result, l, k, i, j) = DIRECT_NZYX_ELEM(multidimArray, n, z, y, x);
@@ -1134,6 +1163,12 @@ private:
 #undef DEBUG
 
         if (dataMode < DATA)
+            if (axisOrder != defaultAxisOrder) {
+                std::array<size_t, 4> sizes;
+                getDimensions(sizes[3], sizes[2], sizes[1], sizes[0]);
+                transposeAxisSizes(sizes, axisOrder, sizes);
+                setDimensions(sizes[3], sizes[2], sizes[1], sizes[0]);
+            } 
             return;
 
         if (datatype == DT_UHalfByte){
@@ -1278,6 +1313,7 @@ private:
             // Transposing multidim array
             if (axisOrder != defaultAxisOrder) {
                 transposeInPlace(data, axisOrder);
+                data.getDimensions(aDimFile);
             }
             //if ( pad > 0 )
             //    freeMemory(padpage, pad*sizeof(char));

--- a/core/xmipp_image.h
+++ b/core/xmipp_image.h
@@ -192,7 +192,7 @@ public:
 
         // Find the inverse order
         std::array<size_t,4> inverse_order;
-        for (size_t i = 0; i < transposed_sizes.size(); ++i)
+        for (size_t i = 0; i < inverse_order.size(); ++i)
         {
             size_t j = 0;
             while(j < order.size() && order[j] != i) ++j; // Find inverse mapping

--- a/core/xmipp_image.h
+++ b/core/xmipp_image.h
@@ -1163,6 +1163,7 @@ private:
 #undef DEBUG
 
         if (dataMode < DATA)
+        {
             if (axisOrder != defaultAxisOrder) {
                 std::array<size_t, 4> sizes;
                 getDimensions(sizes[3], sizes[2], sizes[1], sizes[0]);
@@ -1170,6 +1171,7 @@ private:
                 setDimensions(sizes[3], sizes[2], sizes[1], sizes[0]);
             } 
             return;
+        }
 
         if (datatype == DT_UHalfByte){
             //REPORT_ERROR(ERR_MMAP, "Image Class::readData not supported for  "

--- a/core/xmipp_image.h
+++ b/core/xmipp_image.h
@@ -189,11 +189,24 @@ public:
             YSIZE(multidimArray),
             XSIZE(multidimArray)
         };
+
+        // Find the inverse order
+        std::array<size_t,4> inverse_order;
+        for (size_t i = 0; i < transposed_sizes.size(); ++i)
+        {
+            size_t j = 0;
+            while(j < order.size() && order[j] != i) ++j; // Find inverse mapping
+            if (j >= order.size())
+                REPORT_ERROR(ERR_LOGIC_ERROR, "Invalid axis mapping");
+            
+            inverse_order[i] = j;
+        }
+
         MultidimArray<T> result(
-            sizes[order[0]],
-            sizes[order[1]],
-            sizes[order[2]],
-            sizes[order[3]]
+            sizes[inverse_order[0]],
+            sizes[inverse_order[1]],
+            sizes[inverse_order[2]],
+            sizes[inverse_order[3]]
         );
 
         // Performing transposition in a loop for every dimension
@@ -203,10 +216,13 @@ public:
                     for (size_t x = 0; x < XSIZE(multidimArray); x++) {
                         // Defining array to access with the axis orders
                         const std::array<size_t,4> indices = {n, z, y, x};
+                        const auto l = indices[inverse_order[0]];
+                        const auto k = indices[inverse_order[1]];
+                        const auto i = indices[inverse_order[2]];
+                        const auto j = indices[inverse_order[3]];
 
                         // Transposing element
-                        DIRECT_NZYX_ELEM(result, indices[order[0]], indices[order[1]], indices[order[2]], indices[order[3]]) =
-                            DIRECT_NZYX_ELEM(multidimArray, n, z, y, x);
+                        DIRECT_NZYX_ELEM(result, l, k, i, j) = DIRECT_NZYX_ELEM(multidimArray, n, z, y, x);
                     }
                 }
             }


### PR DESCRIPTION
Xmipp reported wrong volume sizes when reading MRC/MAP files with disordered axes. Previous fixes (from Martin and I) fail when axis ordering is not 123 or 321, such as with [EMD-2170](https://www.ebi.ac.uk/emdb/EMD-2170), which has 213 ordering. These exotic axis orderings are somewhat common in crystallography.