### PR TITLE
Added MADV_HUGEPAGE support check

### DIFF
--- a/core/utils/memory_utils.h
+++ b/core/utils/memory_utils.h
@@ -71,7 +71,9 @@ namespace memoryUtils
     inline T* page_aligned_alloc(size_t elems, bool initToZero) {
         size_t bytes = elems * sizeof(T);
         auto p = (T*)page_aligned_alloc(bytes);
-        madvise(p, bytes, MADV_HUGEPAGE);
+        #ifdef MADV_HUGEPAGE
+            madvise(p, bytes, MADV_HUGEPAGE); // Not available in all platforms
+        #endif
         if (initToZero) {
             memset(p, 0, bytes);
         }


### PR DESCRIPTION
In some operating systems `MADV_HUGEPAGE` is not available. Adding a check to only use it when defined.