### PR TITLE
Manage libstdc++.so.6; version GLIBCXX_x.x.x not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ find_package(Threads REQUIRED)
 
 find_package(FFTW REQUIRED)
 
+find_library(LIBSTDCXX_LIBRARY stdc++)
+
 # Register all source and header files
 file(GLOB_RECURSE 
 	SOURCES 
@@ -97,6 +99,16 @@ target_link_libraries(
 		FFTW::FloatThreads
 		${HDF5_LIBRARIES}
 )
+
+if(LIBSTDCXX_LIBRARY)
+	message("Linking to libstdc++ at ${LIBSTDCXX_LIBRARY}")
+	target_link_libraries(
+        	${PROJECT_NAME}
+        	PUBLIC
+			${LIBSTDCXX_LIBRARY}
+	)
+
+endif()
 
 # Install library's binary files and headers
 install(


### PR DESCRIPTION
Forcing to compile Xmipp with the libstdc++ availabe in the scipion3 env
https://github.com/I2PC/xmippCore/issues/211