### PR TITLE
Allowing to dont sort in split metadata method

### DIFF
--- a/core/metadata_vec.cpp
+++ b/core/metadata_vec.cpp
@@ -820,7 +820,10 @@ void MetaDataVec::split(size_t parts, std::vector<MetaDataVec> &results, const M
         REPORT_ERROR(ERR_MD, "MetaDataDb::split: Couldn't split a metadata in more parts than its size");
 
     MetaDataVec sorted;
-    sorted.sort(*this, sortLabel);
+    if (sortLabel == MDL_UNDEFINED)
+        sorted = *this;
+    else
+        sorted.sort(*this, sortLabel);
 
     results.clear();
     results.resize(parts);


### PR DESCRIPTION
Allowing to skip sorting in metadata_vec::split