### PR TITLE
Fixing read when encountering NaN-s and infinite values

### DIFF
--- a/core/metadata_object.cpp
+++ b/core/metadata_object.cpp
@@ -462,7 +462,19 @@ bool MDObject::fromStream(std::istream &is, bool fromString)
             data.longintValue = (size_t) d;
             break;
         case LABEL_DOUBLE:
-            is >> data.doubleValue;
+            {
+                std::string tmp;
+                is >> tmp;
+
+                char* end = nullptr;
+                data.doubleValue = std::strtod(tmp.c_str(), &end);
+                
+                if (end != tmp.c_str() + tmp.size())
+                {
+                    // Set failure flag
+                    is.setstate(std::ios::failbit);
+                }
+            }
             break;
         case LABEL_STRING:
             {


### PR DESCRIPTION
Xmipp stops reading metadata files when encountering NaN-s or inifinity values in a column. 

How to test:
```
data_noname
loop_
 _anglePsi
    0.000000 
   12.000000 
   inf
   nan
   10.000000
```

Closes [#209](https://github.com/I2PC/xmippCore/issues/209)