### PR TITLE
Range for hdf5 1.8 <= version <= 1.12.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 # Find dependencies
 find_package(HDF5 1.8 COMPONENTS C CXX REQUIRED)
+if (HDF5_VERSION VERSION_GREATER "1.12.2")
+    message(FATAL_ERROR
+        "HDF5 ${HDF5_VERSION} found, but is required <= 1.12.2")
+endif()
+
 if(XMIPP_VERSIONS_FILE)
 	file(APPEND ${XMIPP_VERSIONS_FILE} "HDF5=${HDF5_VERSION}\n")
 endif()


### PR DESCRIPTION
- HDF5 > 1.12.2 requires GCC >= 11.4
- HDF5 > 1.12.6 requires GCC >= 13

Conda channel install by default the hdf5 1.14.6. 
As the Scipion3 environment compile with the libstdc++, and use to be the newest, there are some rerros related to the old version of the GCC in the system.
Fixing a range available we avoid that error. 